### PR TITLE
Feature/background switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ To try it out, simply clone this repository, install `textual` and `segno` with 
 * `code` - generate QR codes to display in the tabling app
 
 ## Usage: Run
-Arguments are currently reserved for the Run command but their implementation is not yet finished.
+Arguments are currently reserved for the Run command but their implementation is not yet fully complete.
 The `run` subcommand will always run the tabling app.
+* `-n`, `--no-backgrounds` : disable the backgrounds and only use the default purple hexadecimal background.
+* `-b BACKGROUND[...]`, `--backgrounds BACKGROUND[...]` : specify one or more backgrounds to use when running the tabling program.
 
 ## Usage: Code
 * `data`: the data that should be encoded in the QR code.

--- a/assets/screenshot.png
+++ b/assets/screenshot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b19b206c7c6340704b62215e59b18fedc688ea3f8e770d60ce78cfcb0a45732e
-size 4612638
+oid sha256:03a4b92ab1b91c20db0100df205c1ab57a7eb20fd67e078de5bb667d1d0b862e
+size 4451858

--- a/assets/snake_screenshot.png
+++ b/assets/snake_screenshot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe2071aa285229d51665f3dc613fc1ac5286f1f0c8a4981fef8be0f4f7e69945
-size 4612638
+oid sha256:818de58870d88d604cc69b941601d7abece7d5e8491ca699919c898ff1daf7dd
+size 4451858

--- a/backgrounds/background_default.py
+++ b/backgrounds/background_default.py
@@ -37,7 +37,6 @@ class DefaultBackground(Static, BackgroundBase, metaclass=BackgroundMetaClass):
     
     def finish(self) -> None:
         self.post_message(BackgroundBase.BackgroundEnded())
-
     
     @on(events.Resize)
     def on_event_resize(self, message: events.Resize) -> None:

--- a/backgrounds/background_default.py
+++ b/backgrounds/background_default.py
@@ -1,5 +1,6 @@
 from textual import on
 from textual.widgets import Static
+from textual.geometry import Size
 from textual import events
 
 import random
@@ -15,6 +16,10 @@ class DefaultBackground(Static, BackgroundBase, metaclass=BackgroundMetaClass):
 	    width: 1fr;
     }
     """
+
+    def __init__(self, id=None):
+        self.old_size = Size()
+        super().__init__(id=id)
 
     def author(self) -> str:
         return "Mac Coleman"
@@ -36,8 +41,11 @@ class DefaultBackground(Static, BackgroundBase, metaclass=BackgroundMetaClass):
     
     @on(events.Resize)
     def on_event_resize(self, message: events.Resize) -> None:
+        if (message.size == self.old_size):
+            return None
 
         self.update_hex_text(message.size.width, message.size.height)
+        self.old_size = message.size
     
     def update_hex_text(self, width: int, height: int) -> str:
         numbers = height * (width//3)
@@ -53,6 +61,10 @@ class DefaultBackgroundRed(Static, BackgroundBase, metaclass=BackgroundMetaClass
 	    width: 1fr;
     }
     """
+
+    def __init__(self, id=None):
+        self.old_size = Size()
+        super().__init__(id=id)
 
     def author(self) -> str:
         return "Mac Coleman"
@@ -75,8 +87,11 @@ class DefaultBackgroundRed(Static, BackgroundBase, metaclass=BackgroundMetaClass
     
     @on(events.Resize)
     def on_event_resize(self, message: events.Resize) -> None:
+        if (message.size == self.old_size):
+            return None
 
         self.update_hex_text(message.size.width, message.size.height)
+        self.old_size = message.size
     
     def update_hex_text(self, width: int, height: int) -> str:
         numbers = height * (width//3)

--- a/backgrounds/background_default.py
+++ b/backgrounds/background_default.py
@@ -23,10 +23,55 @@ class DefaultBackground(Static, BackgroundBase, metaclass=BackgroundMetaClass):
         return "Purple Hexadecimal"
     
     def start(self) -> None:
+        self.styles.opacity = 0.0
+        self.styles.animate("opacity", 1.0, duration=2.0)
+
+    def stop(self) -> None:
+        self.styles.opacity = 1.0
+        self.styles.animate("opacity", 0.0, duration=2.0, on_complete=self.finish)
+    
+    def finish(self) -> None:
+        self.post_message(BackgroundBase.BackgroundEnded())
+
+    
+    @on(events.Resize)
+    def on_event_resize(self, message: events.Resize) -> None:
+
+        self.update_hex_text(message.size.width, message.size.height)
+    
+    def update_hex_text(self, width: int, height: int) -> str:
+        numbers = height * (width//3)
+        string = " ".join(["{:02X}".format(random.randint(0,255)) for x in range(numbers)])
+        self.update(string)
+
+class DefaultBackgroundRed(Static, BackgroundBase, metaclass=BackgroundMetaClass):
+    DEFAULT_CSS = """
+    DefaultBackgroundRed {
+        align: center middle;
+	    color: #990045;
+	    height: 1fr;
+	    width: 1fr;
+    }
+    """
+
+    def author(self) -> str:
+        return "Mac Coleman"
+    
+    def title(self) -> str:
+        return "Red Hexadecimal"
+    
+    def start(self) -> None:
+        self.styles.opacity = 0.0
+        self.styles.animate("opacity", 1.0, duration=2.0)
         pass
 
     def stop(self) -> None:
+        self.styles.opacity = 1.0
+        self.styles.animate("opacity", 0.0, duration=2.0, on_complete=self.finish)
         pass
+    
+    def finish(self) -> None:
+        self.post_message(BackgroundBase.BackgroundEnded())
     
     @on(events.Resize)
     def on_event_resize(self, message: events.Resize) -> None:

--- a/backgrounds/background_rainbow_hex.py
+++ b/backgrounds/background_rainbow_hex.py
@@ -1,0 +1,61 @@
+from textual.widgets import Static
+from textual.geometry import Size
+from textual.color import Color
+from textual import events, on
+
+import random
+
+from .background import BackgroundBase, BackgroundMetaClass
+
+class RainbowHex(Static, BackgroundBase, metaclass=BackgroundMetaClass):
+    DEFAULT_CSS = """
+    RainbowHex {
+        align: center middle;
+	    color: #990045;
+	    height: 1fr;
+	    width: 1fr;
+    }
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.old_size = Size()
+        self.color_list = [Color.from_hsl(x/100, 1.0, 0.25) for x in range(0, 100, 5)]
+        self.color_index = 0
+        super().__init__(*args, **kwargs)
+
+    def author(self) -> str:
+        return "Mac Coleman"
+    
+    def title(self) -> str:
+        return "Rainbow Hexadecimal"
+    
+    def start(self) -> None:
+        self.styles.opacity = 0.0
+        self.styles.animate("opacity", 1.0, duration=2.0, on_complete=self.next_color)
+        pass
+
+    def next_color(self) -> None:
+        self.styles.animate("color", self.color_list[self.color_index].css, duration=0.5, on_complete=self.next_color)
+        self.color_index = (self.color_index + 1) % len(self.color_list)
+
+    def stop(self) -> None:
+        self.stop_animation("color")
+        self.styles.opacity = 1.0
+        self.styles.animate("opacity", 0.0, duration=2.0, on_complete=self.finish)
+        pass
+    
+    def finish(self) -> None:
+        self.post_message(BackgroundBase.BackgroundEnded())
+    
+    @on(events.Resize)
+    def on_event_resize(self, message: events.Resize) -> None:
+        if (message.size == self.old_size):
+            return None
+
+        self.update_hex_text(message.size.width, message.size.height)
+        self.old_size = message.size
+    
+    def update_hex_text(self, width: int, height: int) -> str:
+        numbers = height * (width//3)
+        string = " ".join(["{:02X}".format(random.randint(0,255)) for x in range(numbers)])
+        self.update(string)

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from snake import SnakeMenu, SnakeGame
 from backgrounds.background import BackgroundBase
 
 from backgrounds.background_default import DefaultBackground, DefaultBackgroundRed
+from backgrounds.background_rainbow_hex import RainbowHex
 
 import argparse
 
@@ -49,22 +50,23 @@ class TablingApp(App):
         self.current_user = ("EMPTY", "EMPTY")
         
         self.qr_code = False
-        with ContentSwitcher(initial="default", id="backgrounds", classes="BackgroundHolder") as background_switcher:
+        with ContentSwitcher(initial=self.current_background_id, id="backgrounds", classes="BackgroundHolder") as background_switcher:
             self.background_switcher = background_switcher
 
             for i, (id, background_class) in enumerate(self.backgrounds.items()):
                 yield background_class(id=id)
                 # Add all of the backgrounds to the app.
             
-            background_switcher.current = self.current_background_id
-            
         with ContentSwitcher(initial="signup", id="menus", classes="MenuHolder"):
             yield SignupMenu(id="signup")
             yield QrCodeMenu(id="qr-code")
             yield SnakeMenu(id="snake")
         
+        self.background_switcher.current = self.current_background_id
         self.background_switcher.visible_content.start()
-        self.background_timer = self.set_timer(10, self.next_background)
+        
+        if len(self.backgrounds) > 1:
+            self.background_timer = self.set_timer(10, self.next_background)
 
         title = self.background_switcher.visible_content.title()
         author = self.background_switcher.visible_content.author()
@@ -225,7 +227,8 @@ def handle_run(args):
 
     available_backgrounds = {
         "default" : DefaultBackground,
-        "red" : DefaultBackgroundRed
+        "red" : DefaultBackgroundRed,
+        "rainbow_hex" : RainbowHex
     }
 
     TablingApp(False, available_backgrounds).run()

--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ class TablingApp(App):
         self.background_ids = list(backgrounds.keys())
         self.current_background_index = 0
         self.current_background_id = self.background_ids[0]
+        self.background_switch_time = 45
         super().__init__()
 
     def compose(self) -> ComposeResult:
@@ -66,7 +67,7 @@ class TablingApp(App):
         self.background_switcher.visible_content.start()
         
         if len(self.backgrounds) > 1:
-            self.background_timer = self.set_timer(10, self.next_background)
+            self.background_timer = self.set_timer(self.background_switch_time, self.next_background)
 
         title = self.background_switcher.visible_content.title()
         author = self.background_switcher.visible_content.author()
@@ -82,7 +83,7 @@ class TablingApp(App):
         self.current_background_id = self.background_ids[self.current_background_index]
         self.background_switcher.current = self.current_background_id
         self.background_switcher.visible_content.start()
-        self.background_timer = self.set_timer(10, self.next_background)
+        self.background_timer = self.set_timer(self.background_switch_time, self.next_background)
 
         title = self.background_switcher.visible_content.title()
         author = self.background_switcher.visible_content.author()

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from signup_menu import SignupMenu
 from qr_code_menu import QrCodeMenu
 from snake import SnakeMenu, SnakeGame
 
+from backgrounds.background import BackgroundBase
+
 from backgrounds.background_default import DefaultBackground
 
 import argparse
@@ -31,6 +33,10 @@ class TablingApp(App):
         Binding("escape", "switch_qr_code_display()", 'display_qr_code', show=False, priority=True),
     ]
 
+    def __init__(self, signup_only: bool, backgrounds: dict[str, BackgroundBase]):
+        self.signup_only = signup_only
+        self.backgrounds = backgrounds
+        super().__init__()
 
     def compose(self) -> ComposeResult:
 
@@ -38,7 +44,11 @@ class TablingApp(App):
         
         self.qr_code = False
         with ContentSwitcher(initial="default", id="backgrounds", classes="BackgroundHolder"):
-            yield DefaultBackground(id="default")
+
+            for i, (id, background_class) in enumerate(self.backgrounds.items()):
+                yield background_class(id=id)
+                # Add all of the backgrounds to the app.
+            
         with ContentSwitcher(initial="signup", id="menus", classes="MenuHolder"):
             yield SignupMenu(id="signup")
             yield QrCodeMenu(id="qr-code")
@@ -180,7 +190,12 @@ def write_qr_code(data: str, density: int, allow_micro=False):
         return output
 
 def handle_run(args):
-    TablingApp().run()
+
+    available_backgrounds = {
+        "default" : DefaultBackground
+    }
+
+    TablingApp(False, available_backgrounds).run()
 
 def handle_qr_codes(args):
 

--- a/main.py
+++ b/main.py
@@ -63,26 +63,28 @@ class TablingApp(App):
             yield QrCodeMenu(id="qr-code")
             yield SnakeMenu(id="snake")
         
-        self.background_switcher.query_one(f"#{self.current_background_id}").start()
+        self.background_switcher.visible_content.start()
         self.background_timer = self.set_timer(10, self.next_background)
 
-        background = self.background_switcher.query_one(f"#{self.current_background_id}")
-        self.query_one("#_default").border_subtitle = f"[i]{background.title()}[/i] by {background.author()}"
+        title = self.background_switcher.visible_content.title()
+        author = self.background_switcher.visible_content.author()
+        self.query_one("#_default").border_subtitle = f"[i]{title}[/i] by {author}"
     
     def next_background(self):
         """Tell the current background to stop."""
-        self.background_switcher.query_one(f"#{self.current_background_id}").stop()
+        self.background_switcher.visible_content.stop()
     
     @on(BackgroundBase.BackgroundEnded)
     def background_ended(self, message: BackgroundBase.BackgroundEnded) -> None:
         self.current_background_index = (self.current_background_index + 1) % len(self.background_ids)
         self.current_background_id = self.background_ids[self.current_background_index]
         self.background_switcher.current = self.current_background_id
-        self.background_switcher.query_one(f"#{self.current_background_id}").start()
+        self.background_switcher.visible_content.start()
         self.background_timer = self.set_timer(10, self.next_background)
 
-        background = self.background_switcher.query_one(f"#{self.current_background_id}")
-        self.query_one("#_default").border_subtitle = f"[i]{background.title()}[/i] by {background.author()}"
+        title = self.background_switcher.visible_content.title()
+        author = self.background_switcher.visible_content.author()
+        self.query_one("#_default").border_subtitle = f"[i]{title}[/i] by {author}"
     
     def on_signup_menu_name_entered(self, message: SignupMenu.NameEntered):
         self.current_user = (message.name, message.email_address)

--- a/main.py
+++ b/main.py
@@ -231,7 +231,20 @@ def handle_run(args):
         "rainbow_hex" : RainbowHex
     }
 
-    TablingApp(False, available_backgrounds).run()
+    selected_backgrounds = {}
+
+    if args.no_backgrounds == True:
+        selected_backgrounds["default"] = DefaultBackground
+    elif args.backgrounds != None:
+        for name in args.backgrounds:
+            try:
+                selected_backgrounds[name.lower()] = available_backgrounds[name.lower()]
+            except KeyError as e:
+                print(f"'{name}' is not a valid background.")
+    else:
+        selected_backgrounds = available_backgrounds
+
+    TablingApp(False, selected_backgrounds).run()
 
 def handle_qr_codes(args):
 


### PR DESCRIPTION
This pull request is to add the background switching feature as laid out in #5.

The main tabling app has now been changed so that backgrounds are contained within a content switcher, which automatically switches between the available backgrounds. Backgrounds can be specified from the command line with the `-b` flag, or disabled with the `-n`/`--no-backgrounds` flag.

The time between backgrounds can be adjusted with the `TablingApp.background_switch_time` parameter, which currently sits at 45 seconds. This means that 45 seconds after a background begins displaying, the app will request that it clean up and shut down. When the `BackgroundBase.BackgroundEnded` event is posted, the app will continue to the next background and begin displaying it.

An example background, `RainbowHex` (in `backgrounds/background_rainbow_hex.py`) has been added to provide an example of a background class. It makes use of textual's animation functions to smoothly transition the hexadecimal text between colors. This may have a negative effect on the performance of the app. In the future, it may be a good idea to restrict the available backgrounds to make sure that they don't paint too much of the screen too frequently, as textual's animation functions do. Further research should be done to confirm this, though.